### PR TITLE
remove outdated news messages

### DIFF
--- a/src/overrides/main.html
+++ b/src/overrides/main.html
@@ -5,8 +5,8 @@
     <!-- <font size="+2"><strong><a href="{{ base_url }}/news/2025-07-21" style="--md-typeset-a-color: var(--md-code-fg-color);">2025 TC Virtual Poster Session and Networking Event</a></strong></font><br/> -->
     <!-- <font size="+2"><strong><a href="{{ base_url }}/news/2025-03-05" style="--md-typeset-a-color: var(--md-code-fg-color);">Optimization for Robotics Summer School: Registration open!</a></strong></font><br/> -->
     <!-- <font size="+2"><strong><a href="{{ base_url }}/news/2025-04-16-best-paper" style="--md-typeset-a-color: var(--md-code-fg-color);">2024 TC Best Paper Award Results!</a></strong></font><br/> -->
-    <font size="+2"><strong><a href="{{ base_url }}/news/2026-01-22" style="--md-typeset-a-color: var(--md-code-fg-color);">Call for Student Representatives! Apply till 15th Feb 2026!</a></strong></font><br/>
-    <font size="+2"><strong><a href="{{ base_url }}/news/2025-12-23" style="--md-typeset-a-color: var(--md-code-fg-color);">2025 TC Best Paper Award Nominations Open!</a></strong></font><br/>
+    <!-- <font size="+2"><strong><a href="{{ base_url }}/news/2026-01-22" style="--md-typeset-a-color: var(--md-code-fg-color);">Call for Student Representatives! Apply till 15th Feb 2026!</a></strong></font><br/> -->
+    <!-- <font size="+2"><strong><a href="{{ base_url }}/news/2025-12-23" style="--md-typeset-a-color: var(--md-code-fg-color);">2025 TC Best Paper Award Nominations Open!</a></strong></font><br/> -->
     <font size="+2"><strong><a href="{{ base_url }}/seminars" style="--md-typeset-a-color: var(--md-code-fg-color);">Seminar Series 2025-26 Line-Up and Video Links</a></strong></font><font size="+2"></font><br/>
     <!-- <font size="+2"><strong><a href="{{ base_url }}/news/2024-11-01" style="--md-typeset-a-color: var(--md-code-fg-color);">TC Happy Hour @Humanoids 2024!</a></strong></font><br/> -->
     <!-- <font size="+2"><strong><a href="{{ base_url }}/news/2024-07-16" style="--md-typeset-a-color: var(--md-code-fg-color);">2024 TC Best Poster Award Results!</a></strong></font><br/> -->


### PR DESCRIPTION
Remove outdated links from the top bar of the website, since the nominations and student representative applications have passed.